### PR TITLE
Fix Boutique style

### DIFF
--- a/Build/theme/default/pages/boutique.php
+++ b/Build/theme/default/pages/boutique.php
@@ -60,7 +60,7 @@
                                     }
                                     for ($i = 1; $i <= count($offresTableau); $i++) :
                                         if ($offresTableau[$i]['categorie'] == $categories[$j]['id']) : ?>
-                                            <div class="col-12 card mx-3 col-md-<?php echo (12/$categories[$j]['showNumber']); ?>">
+                                            <div class="col-12 card mx-3 col-md-<?php echo ((12/$categories[$j]['showNumber'])-1); ?>">
                                                 <div class="card-header">
                                                     <?= (($offresTableau[$i]['nbre_vente'] == 0) ? "<s>" . $offresTableau[$i]['nom'] . "</s>" : $offresTableau[$i]['nom']); ?>
                                                     <br /><small>


### PR DESCRIPTION
Retire -1 au col-md des offres, pour éviter des bugs et laisser un espace supplémentaire (Le MX-3 pourrait empêcher le placement optimal si les col ont la taille exacte