### PR TITLE
Remove htmlspecialchars in BindParam

### DIFF
--- a/modele/forum/forum.class.php
+++ b/modele/forum/forum.class.php
@@ -133,7 +133,7 @@ class Forum {
 	public function infosSousForumTopics($id, $count)
 	{
 		$topic = $this->bdd->prepare('SELECT * FROM cmw_forum_post WHERE sous_forum LIKE :sous_forum ORDER BY epingle DESC, last_answer_temps DESC LIMIT '.$count.', 20');
-		$topic->bindParam(':sous_forum', htmlspecialchars($id));
+		$topic->bindParam(':sous_forum', $id);
         $topic->execute();
 		return $topic->fetchAll(PDO::FETCH_ASSOC);
 	}


### PR DESCRIPTION
ligne 136, fonction php htmlspecialchars créé un warning php, pas de fonction php dans un bindparam